### PR TITLE
Add English comments and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # OTVis
 
-OTVis는 OWL 온톨로지의 TBox 구조를 시각화하기 위한 도구 모음입니다. 파이썬 스크립트로 공리와 주석을 추출해 JSON으로 변환한 후, `index.html`에서 D3.js를 사용해 그래프로 표현합니다.
+OTVis is a collection of utilities for visualizing the TBox structure of OWL ontologies. The provided Python scripts extract axioms and annotations into JSON files and `index.html` uses D3.js to display them as a graph.
 
-## 디렉터리 구조
-- `Ontology/` – 입력 OWL 파일
-- `Axiom_per_entity/` – 개별 클래스/프로퍼티의 공리 정보(`*_axiom.json`)
-- `Ontology_description/` – 클래스와 프로퍼티 설명(`*_description.json`)
-- `Graph/` – 시각화용 그래프 데이터(`*_graph.json`)
-- `ontology_list.json` – 웹에서 선택할 수 있는 온톨로지 이름 목록
-- 주요 스크립트: `ontology_processing.py`, `description_extraction.py`, `convert_hierarchy.py`
+## Directory layout
+- `Ontology/` – input OWL files
+- `Axiom_per_entity/` – axioms for each class/property (`*_axiom.json`)
+- `Ontology_description/` – descriptions of classes and properties (`*_description.json`)
+- `Graph/` – graph data used by the viewer (`*_graph.json`)
+- `ontology_list.json` – list of ontology names shown on the web page
+- Main scripts: `ontology_processing.py`, `description_extraction.py`, `convert_hierarchy.py`
 
-## 파이썬 스크립트
+## Python scripts
 
 ### ontology_processing.py
-온톨로지에서 클래스 및 프로퍼티 공리를 수집하여 JSON으로 저장합니다.
+Collects class and property axioms from the ontology and saves them as JSON.
 
 ```python
 output = {"classes": class_axioms, "properties": prop_axioms}
@@ -22,7 +22,7 @@ with open(axioms_file, "w", encoding="utf-8") as af:
 ```
 
 ### description_extraction.py
-`rdfs:comment`와 `oboInOwl:hasDefinition` 등을 추출해 설명 파일을 만듭니다.
+Extracts `rdfs:comment` and `oboInOwl:hasDefinition` annotations into a description file.
 
 ```python
 output = {
@@ -37,7 +37,7 @@ with open(out_path, "w", encoding="utf-8") as f:
 ```
 
 ### convert_hierarchy.py
-클래스 계층을 읽어 그래프 JSON을 생성하며, 공리와 설명 정보를 병합합니다.
+Reads the class hierarchy to generate a graph JSON and merges the axiom and description information.
 
 ```python
 axiom_path = os.path.join(AXIOM_DIR, f"{base_name}_axiom.json")
@@ -50,8 +50,8 @@ if node in class_descriptions:
     node_dict["description"] = class_descriptions[node]
 ```
 
-## 웹 뷰어
-`index.html`은 D3.js로 인터랙티브 그래프를 표시합니다. 상단에서 온톨로지를 선택하고 특정 클래스로 포커스할 수 있습니다.
+## Web viewer
+`index.html` displays an interactive graph with D3.js. Use the top panel to select an ontology and focus on a specific class.
 
 ```html
 <div id="controls">
@@ -65,7 +65,7 @@ if node in class_descriptions:
 </div>
 ```
 
-온톨로지 목록을 읽어와 선택지를 채우고, `loadOntology()`에서 그래프 데이터를 불러옵니다.
+The page loads the ontology list and `loadOntology()` fetches the graph data.
 
 ```javascript
 fetch("ontology_list.json")
@@ -87,20 +87,21 @@ function loadOntology() {
 }
 ```
 
-## 사용 방법
-1. `Ontology/` 폴더에 OWL 파일을 넣고, 필요한 경우 `ontology_list.json`에 이름을 추가합니다.
-2. Python 3 환경에서 RDFlib을 설치합니다.
+## Usage
+1. Place OWL files in `Ontology/` and add their names to `ontology_list.json` if needed.
+2. Install RDFlib for Python 3.
    ```bash
    pip install rdflib
    ```
-3. 아래 스크립트를 순서대로 실행해 JSON 데이터를 생성합니다.
+3. Run the scripts in order to generate the JSON data.
    ```bash
    python ontology_processing.py
    python description_extraction.py
    python convert_hierarchy.py
    ```
-4. 로컬 웹 서버를 실행하고 브라우저에서 `index.html`을 열어 그래프를 확인합니다.
+4. Start a local web server and open `index.html` in your browser.
    ```bash
    python -m http.server
    ```
-   그 후 `http://localhost:8000/index.html`에 접속하면 됩니다.
+   Then visit `http://localhost:8000/index.html`.
+

--- a/convert_hierarchy.py
+++ b/convert_hierarchy.py
@@ -1,3 +1,5 @@
+"""Convert class hierarchies to a graph JSON format and merge annotation data."""
+
 import os
 import json
 from rdflib import Graph, RDFS, OWL, BNode, URIRef
@@ -13,6 +15,7 @@ TARGET_WITH_LABEL = [
 ]
 
 def safe_qname(node, g, label_map=None):
+    """Return a qname or label for *node* if available."""
     if label_map and node in label_map:
         return label_map[node]
     try:
@@ -21,6 +24,7 @@ def safe_qname(node, g, label_map=None):
         return str(node)
 
 def extract_force_graph(file_path, output_path):
+    """Parse *file_path* and write a force-layout graph JSON to *output_path*."""
     g = Graph()
     if file_path.endswith((".owl", ".rdf")):
         parse_format = "xml"
@@ -58,7 +62,7 @@ def extract_force_graph(file_path, output_path):
             links.append({"source": r, "target": "owl:Thing"})
             nodes.add("owl:Thing")
 
-    # ------ 🔥 axiom 및 description 병합 ------
+    # ------ 🔥 merge axioms and descriptions ------
     axiom_path = os.path.join(AXIOM_DIR, f"{base_name}_axiom.json")
     desc_path = os.path.join(DESC_DIR, f"{base_name}_description.json")
     class_axioms = {}
@@ -79,10 +83,10 @@ def extract_force_graph(file_path, output_path):
     node_list = []
     for node in sorted(nodes):
         node_dict = {"id": node}
-        # axiom 병합
+        # merge axioms
         if node in class_axioms:
             node_dict["axioms"] = class_axioms[node]
-        # description 병합 (필드 그대로 모두 넣음)
+        # merge descriptions (include all fields as is)
         if node in class_descriptions:
             node_dict["description"] = class_descriptions[node]
         node_list.append(node_dict)

--- a/description_extraction.py
+++ b/description_extraction.py
@@ -1,16 +1,17 @@
+"""Extract annotations from OWL files and store them as JSON."""
+
 import os
 import json
 from rdflib import Graph, Namespace
 from rdflib.namespace import RDF, RDFS, OWL
 
-# ——————————————————————————————————————————
-# 1) owl files to be processed label replacement
+# Names of ontology files where labels should replace QNames
 TARGET_WITH_LABEL = [
     "swo_merged.owl",
     "OntoDT.owl"
 ]
 
-# input/output directory
+# Input and output directories
 INPUT_DIR = "Ontology"
 OUTPUT_DIR = "Ontology_description"
 os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -20,12 +21,7 @@ OBOINOWL = Namespace("http://www.geneontology.org/formats/oboInOwl#")
 
 
 def format_node(node, g, label_map=None):
-    """
-    node → human-readable string
-    1) if label_map[node] exists, return label_map[node]
-    2) else, return qname(node)
-    3) if failed, return str(node)
-    """
+    """Return a readable identifier for *node* using labels or qnames."""
     if label_map and node in label_map:
         return label_map[node]
     try:
@@ -124,3 +120,4 @@ for fname in os.listdir(INPUT_DIR):
     class_count = len(class_ann_dict)
     prop_count = len(prop_ann_dict)
     print(f"✔️ {fname} → {out_fname} saved (use_label={use_label}, #classes: {class_count}, #properties: {prop_count})")
+

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         fill: black;
         pointer-events: none;
       }
-      /* --- 패널 스타일 --- */
+      /* --- panel style --- */
       #desc-axiom-panel {
         position: absolute;
         top: 10px;
@@ -79,8 +79,8 @@
         font-size: 13px;
         line-height: 1.45;
         overflow-x: auto;
-        font-family: inherit; /* 이 줄 추가! */
-        font-weight: normal; /* 선택사항: 두께 통일 */
+        font-family: inherit; /* added line */
+        font-weight: normal; /* optional: same weight */
         margin: 0;
       }
 
@@ -116,7 +116,7 @@
       <ul id="children-list" style="list-style: none; padding-left: 10px; font-size: 15px"></ul>
     </div>
 
-    <!-- 우상단 클래스 설명/공리 패널 -->
+      <!-- panel for class description and axioms -->
     <div id="desc-axiom-panel" style="display: none">
       <h2 id="panel-class-label">Class info</h2>
       <div id="desc-content"></div>
@@ -160,7 +160,7 @@
 
       function loadOntology() {
         const name = document.getElementById("ontology-select").value
-        const filePath = `Graph/${name}_graph.json?v=${Date.now()}` // 캐시 방지
+        const filePath = `Graph/${name}_graph.json?v=${Date.now()}` // prevent caching
 
         svgGroup.selectAll("#link-layer, #node-layer").remove()
         if (simulation) simulation.stop()
@@ -171,7 +171,7 @@
             allLinks = data.links
             assignColors(data)
             renderGraph(data)
-            document.getElementById("desc-axiom-panel").style.display = "none" // ontology reload 시 패널 숨김
+            document.getElementById("desc-axiom-panel").style.display = "none" // hide panel when ontology reloads
           })
           .catch(() => alert("File not found: " + filePath))
       }
@@ -214,7 +214,7 @@
         svgGroup.selectAll("#node-layer").remove()
         svgGroup.selectAll("#axiom-label-layer").remove()
 
-        // ... (node 생성 동일)
+        // ... node creation is the same as above
         const link = svgGroup
           .append("g")
           .attr("id", "link-layer")
@@ -277,7 +277,7 @@
               .forceLink(data.links)
               .id((d) => d.id)
               .distance(40)
-              .strength((d) => (d._axiom ? 0.01 : 0.3)) // ← 여기!
+              .strength((d) => (d._axiom ? 0.01 : 0.3)) // tweak strength here
           )
           .force("charge", d3.forceManyBody().strength(-150))
           .force("center", d3.forceCenter(window.innerWidth / 2, window.innerHeight / 2))
@@ -378,11 +378,11 @@
           ul.appendChild(li)
         })
 
-        // 1. 이전 axiomLinks 제거
+        // 1. remove previous axiomLinks
         allLinks = allLinks.filter((l) => !l._axiom)
         axiomLinks = []
 
-        // 2. 새 axiom edge 추출
+        // 2. extract new axiom edges
         if (target.axioms) {
           for (const [k, vals] of Object.entries(target.axioms)) {
             if (k === "subClassOf") continue
@@ -390,7 +390,7 @@
             axStrs.forEach((ax) => {
               allNodes.forEach((n) => {
                 if (n.id !== target.id && new RegExp(`\\b${escapeRegExp(n.id)}\\b`).test(ax)) {
-                  // 👇 propertyRestrictions이면 ax 그대로, 아니면 '[k] ax'
+                  // if propertyRestrictions, use ax as is; otherwise prefix with '[k]'
                   let edgeLabel = k === "propertyRestrictions" ? ax : k + " " + ax
                   axiomLinks.push({
                     source: target.id,
@@ -404,7 +404,7 @@
           }
         }
 
-        // 3. axiom edge 추가 후 그래프 다시 그림
+        // 3. add axiom edges and redraw graph
         allLinks = allLinks.concat(axiomLinks)
         renderGraph({ nodes: allNodes, links: allLinks })
       }
@@ -414,7 +414,7 @@
         const classLabel = node.id
         document.getElementById("panel-class-label").textContent = classLabel
 
-        // --- Description (변경 없음) ---
+        // --- Description (unchanged) ---
         let descHtml = ""
         if (node.description) {
           for (const [key, value] of Object.entries(node.description)) {
@@ -430,18 +430,18 @@
         }
         document.getElementById("desc-content").innerHTML = descHtml
 
-        // --- Axioms: 노드 이름 감지 후 링크로 대체 ---
+        // --- Axioms: replace node names with links ---
         let axiomHtml = ""
         if (node.axioms) {
           for (const [key, value] of Object.entries(node.axioms)) {
             axiomHtml += `<span class='desc-label'>${key}</span>`
             let axStrs = Array.isArray(value) ? value : [value]
-            // 각 문자열 내에서 노드 이름을 span 링크로 교체
+            // replace node names inside each string with span links
             axiomHtml += "<pre>"
             axStrs.forEach((ax) => {
               let replaced = ax
               allNodes.forEach((n) => {
-                // 정확히 일치하는 부분만 감싸도록 (공백, 구분자, 괄호 등 고려)
+                // wrap only exact matches (consider spaces, punctuation, brackets)
                 replaced = replaced.replace(new RegExp(`\\b${escapeRegExp(n.id)}\\b`, "g"), `<span class="node-link" data-id="${n.id}">${n.id}</span>`)
               })
               axiomHtml += replaced + "\n"
@@ -454,7 +454,7 @@
         document.getElementById("axiom-content").innerHTML = axiomHtml
         panel.style.display = "block"
 
-        // --- 링크 이벤트 부착 ---
+        // --- attach link events ---
         document.querySelectorAll("#axiom-content .node-link").forEach((span) => {
           span.style.color = "#3a5dff"
           span.style.cursor = "pointer"
@@ -465,7 +465,7 @@
         })
       }
 
-      // 유틸: RegExp용 이스케이프 (노드 id에 특수문자 있을 때)
+      // utility: escape for RegExp when node id contains special characters
       function escapeRegExp(string) {
         return string.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
       }

--- a/ontology_processing.py
+++ b/ontology_processing.py
@@ -1,3 +1,5 @@
+"""Extract class and property axioms from OWL ontologies."""
+
 import sys
 import os
 import json
@@ -6,14 +8,14 @@ from rdflib import Graph, RDF, RDFS, OWL
 from rdflib.namespace import XSD
 import random
 from rdflib import BNode, URIRef
-# ——————————————
-# owl files to be processed label replacement
+
+# List of ontology files where labels should be preferred over QNames
 TARGET_WITH_LABEL = [
     "swo_merged.owl",
     "OntoDT.owl"
 ]
 
-# output directory
+# Output directories
 PREFIX_DIR = "Prefixes"
 AXIOM_DIR = "Axiom_per_entity"
 INPUT_DIR = "Ontology"
@@ -22,6 +24,7 @@ for d in (PREFIX_DIR, AXIOM_DIR):
 
 
 def format_node(node, g, label_map=None):
+    """Return a readable identifier for *node* using the label map or qname."""
     if label_map and node in label_map:
         return label_map[node]
     try:
@@ -31,6 +34,7 @@ def format_node(node, g, label_map=None):
 
 
 def parse_rdf_list(list_node, g):
+    """Return elements of an RDF collection as a Python list."""
     items = []
     while list_node and list_node != RDF.nil:
         first = g.value(list_node, RDF.first)


### PR DESCRIPTION
## Summary
- translate README to English
- add module and inline comments in English for Python scripts
- translate comments in the HTML viewer

## Testing
- `python -m py_compile ontology_processing.py description_extraction.py convert_hierarchy.py`

------
https://chatgpt.com/codex/tasks/task_e_68416c5b860083228735739afc8998db